### PR TITLE
Send an empty array as default parameters.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function createMiddleware(router, validator) {
 
     // Parameters check & assign
     this.parameter = check.parameters(validator,
-      methodDef.parameters || {}, this);
+      methodDef.parameters || [], this);
 
     // Let the implementation happen
     yield next;


### PR DESCRIPTION
`check.parameters` uses `Array.prototype.forEach` on object. Throws TypeError when `parameters` is omitted from swagger spec.
