### PR TITLE
Supporting collectionFormat: 'multi'

### DIFF
--- a/lib/checkers.js
+++ b/lib/checkers.js
@@ -72,7 +72,7 @@ function checkParameter(validator, def, context) {
       } else if (def.collectionFormat === "psv") {
         value = value.split("|");
       } else if (def.collectionFormat === "multi") {
-        throw new ValidationError("multi collectionFormat query parameters currently unsupported");
+        value = ( Array.isArray(value) ? value : [value]);
       } else {
         throw new ValidationError("unknown collectionFormat " + def.collectionFormat);
       }


### PR DESCRIPTION
If it's not an array, then put it in an array, matching the
functionality of split, always guaranteeing an array with at least one
element.

I get that it seems naive, but if this is connected to koa, and koa parses `foo=bar&foo=baz` as `['bar', 'bas']`, collectionFormat: multi matches it